### PR TITLE
Allow Firebase SDK 10.x.y. Fixed mixed source error

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 9.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 10.0
 github "mparticle/mparticle-apple-sdk" ~> 8.0

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Firebase",
                url: "https://github.com/firebase/firebase-ios-sdk.git",
-               .upToNextMajor(from: "9.0.0")),
+               .upToNextMajor(from: "10.0.0")),
     ],
     targets: [
         .target(
@@ -27,7 +27,7 @@ let package = Package(
               .product(name: "FirebaseAnalytics", package: "Firebase"),
             ],
             path: "mParticle-Google-Analytics-Firebase",
-            exclude: ["Info.plist"],
+            exclude: ["Info.plist", "dummy.swift"],
             publicHeadersPath: "."),
     ]
 )

--- a/mParticle-Google-Analytics-Firebase.podspec
+++ b/mParticle-Google-Analytics-Firebase.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 9.0'
+    s.ios.dependency 'Firebase/Core', '~> 10.0'
 
 end


### PR DESCRIPTION
 ## Summary
- Updated Firebase SDK dependency to allow use of 10.x.y
- Fixed `target at «path» contains mixed language source files; feature not supported` error by excluding dummy.swift
